### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,6 +3,9 @@ name: PR Check
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Riyaz002/Woli/security/code-scanning/1](https://github.com/Riyaz002/Woli/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the least privileges required for the workflow. Since the workflow only performs read operations (e.g., checking out the repository and running Gradle commands), we will set `contents: read` as the permission. This ensures that the workflow has only the necessary permissions to complete its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
